### PR TITLE
Improve Test Factory for Debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .idea/
 src/**/*.js
 test/**/*.js
+actions.js
+reducer.js

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ flow MY_FLOW_NAME {
 > npm install
 ```
 
+## Test
+```
+// Run all tests
+> npm test
+
+// Run a test for a single file
+> npm run test-file <Path to file>
+
+// Run all parser tests
+> npm run test-parse
+
+// Run all typechecker tests
+> npm run test-typecheck
+```
+
 ## Authors
 - Gina Bolognesi
 - Jeffrey Doyle

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "ts-node src",
     "build": "npx rollup -c",
     "prepublish": "npm run build",
-    "test": "mocha -r ts-node/register ./test/*"
+    "test": "mocha -r ts-node/register ./test/*",
+    "test-file": "mocha -r ts-node/register ./test/File.spec.ts --",
+    "test-parse": "mocha -r ts-node/register ./test/Parser.spec.ts",
+    "test-typecheck": "mocha -r ts-node/register ./test/TypeCheck.spec.ts"
   },
   "keywords": [
     "redux",

--- a/test/File.spec.ts
+++ b/test/File.spec.ts
@@ -1,0 +1,38 @@
+import 'mocha';
+import * as FileSystem from "fs";
+
+import Logger from "../src/utils/Logger";
+import TestFactory from "./utils/TestFactory";
+import ParserVisitor from '../src/visitor/ParserVisitor';
+import TypeCheckVisitor from '../src/visitor/TypeCheckVisitor';
+
+const file = process.argv.pop() || "";
+
+// Defined here so that test case can be dynamically skipped.
+const testCase = {
+  title: "FloScript Pipeline on a Single File",
+  body: () => {
+    it("Should Pass Parsing", async () => {
+      const program = await TestFactory.readProgram(file)
+      new ParserVisitor(program.program).parse();
+    });
+
+    it("Should Pass TypeChecking", async () => {
+      const program = await TestFactory.readProgram(file);
+      const parser = new ParserVisitor(program.program);
+      const ast = parser.parse();
+      new TypeCheckVisitor(parser.getSymbolTable()).typecheck(ast);
+    });
+
+    // TODO: Test for CodeGen once Implemented.
+    it("Should Pass CodeGen");
+  }
+};
+
+if (FileSystem.existsSync(file)) {
+  describe(testCase.title, testCase.body);
+}
+else {
+  Logger.Log(`Skipping File.spec.ts because file ${file} does not exist!`)
+  describe.skip(testCase.title, testCase.body);
+}


### PR DESCRIPTION
This change includes a new test case for our test factory where you can now run:
```
npm run test-file <path to file> 
```
to test an individual FloScript file.

This should make testing and debugging significantly easier.